### PR TITLE
Update travis config to use rakudo packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,14 @@ env:
     - PATH=/opt/rakudo-pkg/bin:$PATH
   matrix:
     - VERSION=2017.11 REVISION=01
-
-sudo: required
+    - VERSION=2017.10 REVISION=01
 
 os:
   - linux
+  - osx
+
+git:
+  depth: 3
 
 install:
   - wget "https://github.com/nxadm/rakudo-pkg/releases/download/v${VERSION}/rakudo-pkg-Ubuntu14.04_${VERSION}-${REVISION}_amd64.deb" && sudo dpkg -i *.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: generic
+env:
+  global:
+    - PATH=/opt/rakudo-pkg/bin:$PATH
+  matrix:
+    - VERSION=2017.11 REVISION=01
+
+os:
+  - linux
+
+install:
+  - wget "https://github.com/nxadm/rakudo-pkg/releases/download/v${VERSION}/rakudo-pkg-Ubuntu14.04_${VERSION}-${REVISION}_amd64.deb" && sudo dpkg -i *.deb
+  - zef install --deps-only .
+
+script: AUTHOR_TESTING=1 prove -v -e "perl6 -Ilib" t/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: generic
+
 env:
   global:
     - PATH=/opt/rakudo-pkg/bin:$PATH
   matrix:
     - VERSION=2017.11 REVISION=01
+
+sudo: required
 
 os:
   - linux


### PR DESCRIPTION
This should greatly reduce test times, as there's no need to compile all of Perl 6 for every test.